### PR TITLE
Fix tabbing with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@
 all: build
 
 build:
-  npm run build
+	npm run build
 
 dev:
-  npm run build-dev
+	npm run build-dev
 
 gen: build
-  mkdir -p public
-  mkdir -p public/build
-  cp -r pages/* public
-  cp lib/build/main.css public/build
-  cp lib/build/main.js public/build
+	mkdir -p public
+	mkdir -p public/build
+	cp -r pages/* public
+	cp lib/build/main.css public/build
+	cp lib/build/main.js public/build


### PR DESCRIPTION
Originally was getting `Makefile:7: *** missing separator.  Stop.` after running `make dev` 
Resaved in ANSI format (whatever that is)